### PR TITLE
fix: use readline for iterator

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -4,6 +4,7 @@ import {normalize as normalizePath} from 'node:path';
 import {cwd as getCwd} from 'node:process';
 import {computeEnv} from './env.js';
 import {readStreamAsString, combineStreams} from './stream.js';
+import readline from 'node:readline';
 
 export interface Output {
   stderr: string;
@@ -146,8 +147,11 @@ export class ExecProcess implements Result {
       sources.push(proc.stdout);
     }
     const combined = combineStreams(sources);
+    const rl = readline.createInterface({
+      input: combined
+    });
 
-    for await (const chunk of combined) {
+    for await (const chunk of rl) {
       yield chunk.toString();
     }
 


### PR DESCRIPTION
Instead of hoping each chunk is a single line of output, this uses the readline module to read the stream line by line.