### PR TITLE
feat: rework promise interface

### DIFF
--- a/src/test/stream_test.ts
+++ b/src/test/stream_test.ts
@@ -21,12 +21,7 @@ test('readStreamAsString', async (t) => {
         this.destroy(streamError);
       }
     });
-    try {
-      await readStreamAsString(stream);
-      assert.fail('expected to throw');
-    } catch (err) {
-      assert.equal(err, streamError);
-    }
+    await assert.rejects(readStreamAsString(stream), streamError);
   });
 
   await t.test('resolves to concatenated data', async () => {


### PR DESCRIPTION
Reworks the promise `.then` to be greatly simplified.

As part of this, error handling has also been improved in a few ways:

- Timeouts are now handled by an `AbortSignal` rather than the built-in `timeout` option, as there is currently no way to know if a proc was killed due to a timeout.
- The last error is stored until we `await` the result, at which point, we will throw the stored error
- We wait for the process to close before trying to read the output, in case it threw