### PR TITLE
feat: use streams rather than a buffer

### DIFF
--- a/src/stream.ts
+++ b/src/stream.ts
@@ -1,26 +1,6 @@
 import {type EventEmitter} from 'node:events';
 import {type Readable, PassThrough} from 'node:stream';
 
-export const readStreamAsString = (stream: Readable): Promise<string> => {
-  return new Promise<string>((resolve, reject) => {
-    let result = '';
-    const onDataReceived = (chunk: Buffer | string): void => {
-      result += chunk.toString();
-    };
-
-    stream.once('error', (err) => {
-      reject(err);
-    });
-
-    stream.on('data', onDataReceived);
-
-    stream.once('end', () => {
-      stream.removeListener('data', onDataReceived);
-      resolve(result);
-    });
-  });
-};
-
 export const waitForEvent = (
   emitter: EventEmitter,
   name: string

--- a/src/test/main_test.ts
+++ b/src/test/main_test.ts
@@ -1,0 +1,98 @@
+import {x} from '../main.js';
+import * as assert from 'node:assert/strict';
+import {test} from 'node:test';
+
+test('exec', async (t) => {
+  await t.test('resolves to stdout', async () => {
+    const result = await x('echo', ['foo']);
+    assert.equal(result.stdout, 'foo\n');
+    assert.equal(result.stderr, '');
+  });
+
+  await t.test('times out after defined timeout (ms)', async () => {
+    const proc = x('sleep', ['0.2s'], {timeout: 100});
+    await assert.rejects(async () => {
+      await proc;
+    });
+    assert.equal(proc.killed, true);
+    assert.equal(proc.process!.signalCode, 'SIGTERM');
+  });
+
+  await t.test('throws spawn errors', async () => {
+    const proc = x('definitelyNonExistent');
+    await assert.rejects(async () => {
+      await proc;
+    }, 'spawn definitelyNonExistent NOENT');
+  });
+
+  await t.test('captures stderr', async () => {
+    const result = await x('cat', ['nonexistentforsure']);
+    assert.equal(
+      result.stderr,
+      'cat: nonexistentforsure: No such file or directory\n'
+    );
+    assert.equal(result.stdout, '');
+  });
+
+  await t.test('pid is number', async () => {
+    const proc = x('echo', ['foo']);
+    await proc;
+    assert.ok(typeof proc.pid === 'number');
+  });
+
+  await t.test('exitCode is set correctly', async () => {
+    const proc = x('echo', ['foo']);
+    assert.equal(proc.exitCode, undefined);
+    await proc;
+    assert.equal(proc.exitCode, 0);
+  });
+
+  await t.test('kill terminates the process', async () => {
+    const proc = x('sleep', ['5s']);
+    const result = proc.kill();
+    assert.ok(result);
+    assert.ok(proc.killed);
+    assert.equal(proc.aborted, false);
+  });
+
+  await t.test('pipe correctly pipes output', async () => {
+    const echoProc = x('echo', ['foo\nbar']);
+    const grepProc = echoProc.pipe('grep', ['foo']);
+    const result = await grepProc;
+
+    assert.equal(result.stderr, '');
+    assert.equal(result.stdout, 'foo\n');
+    assert.equal(echoProc.exitCode, 0);
+    assert.equal(grepProc.exitCode, 0);
+  });
+
+  await t.test('async iterator gets correct output', async () => {
+    const proc = x('echo', ['foo\nbar']);
+    const lines = [];
+    for await (const line of proc) {
+      lines.push(line);
+    }
+
+    assert.deepEqual(lines, ['foo', 'bar']);
+  });
+
+  await t.test('async iterator receives errors', async () => {
+    const proc = x('nonexistentforsure');
+    await assert.rejects(async () => {
+      for await (const line of proc) {
+        line;
+      }
+    });
+  });
+
+  await t.test('signal can be used to abort execution', async () => {
+    const controller = new AbortController();
+    const proc = x('sleep', ['4s'], {signal: controller.signal});
+    controller.abort();
+    const result = await proc;
+    assert.ok(proc.aborted);
+    assert.ok(proc.killed);
+    assert.equal(result.stderr, '');
+    assert.equal(result.stdout, '');
+  });
+});

--- a/src/test/stream_test.ts
+++ b/src/test/stream_test.ts
@@ -1,4 +1,4 @@
-import {combineStreams, waitForEvent, readStreamAsString} from '../stream.js';
+import {combineStreams, waitForEvent} from '../stream.js';
 import * as assert from 'node:assert/strict';
 import {test} from 'node:test';
 import {EventEmitter} from 'node:events';
@@ -10,36 +10,6 @@ test('waitForEvent', async (t) => {
     const waiter = waitForEvent(emitter, 'foo');
     emitter.emit('foo');
     await waiter;
-  });
-});
-
-test('readStreamAsString', async (t) => {
-  await t.test('rejects on error', async () => {
-    const streamError = new Error('fudge');
-    const stream = new Readable({
-      read() {
-        this.destroy(streamError);
-      }
-    });
-    await assert.rejects(readStreamAsString(stream), streamError);
-  });
-
-  await t.test('resolves to concatenated data', async () => {
-    const stream = Readable.from(['foo', 'bar']);
-    const result = await readStreamAsString(stream);
-    assert.equal(result, 'foobar');
-  });
-
-  await t.test('handles buffer data', async () => {
-    const stream = new Readable({
-      read() {
-        this.push(Buffer.from('foo'));
-        this.push(Buffer.from('bar'));
-        this.push(null);
-      }
-    });
-    const result = await readStreamAsString(stream);
-    assert.equal(result, 'foobar');
   });
 });
 


### PR DESCRIPTION
Reworks the main output method to use streams directly rather than accumulating chunks through events. This should mean we don't hold any output until the user awaits the result.