### PR TITLE
chore: switch the exports around

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,12 +52,12 @@
   "exports": {
     ".": {
       "import": {
-        "default": "./dist/main.js",
-        "types": "./dist/main.d.ts"
+        "types": "./dist/main.d.ts",
+        "default": "./dist/main.js"
       },
       "require": {
-        "default": "./dist/main.cjs",
-        "types": "./dist/main.d.cts"
+        "types": "./dist/main.d.cts",
+        "default": "./dist/main.cjs"
       }
     },
     "./package.json": "./package.json"


### PR DESCRIPTION
Switches the types to be first in the list so some tools will resolve it correctly.

Note this shouldn't really matter for TS itself since it will correctly infer the types.