### PR TITLE
fix: inject a require function to the esm build

### DIFF
--- a/tsup-require-shim.ts
+++ b/tsup-require-shim.ts
@@ -1,0 +1,5 @@
+import {createRequire} from 'node:module';
+
+if (!('require' in globalThis)) {
+  globalThis.require = createRequire(import.meta.url);
+}

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -1,15 +1,26 @@
-import { defineConfig } from "tsup";
+import { defineConfig, type Options } from "tsup";
 
-export default defineConfig({
+const defaultConfig: Options = {
   entryPoints: ["src/main.ts"],
   outDir: "dist",
-  format: ["esm", "cjs"],
   tsconfig: "./tsconfig.json",
-  target: "es2018",
+  target: "es2022",
   minify: false,
   minifySyntax: true,
   minifyWhitespace: false,
   minifyIdentifiers: true,
   clean: true,
   dts: true,
-});
+};
+
+export default defineConfig([
+  {
+    ...defaultConfig,
+    format: ["esm"],
+    inject: ['tsup-require-shim.ts']
+  },
+  {
+    ...defaultConfig,
+    format: ["cjs"]
+  }
+]);


### PR DESCRIPTION
Surprisingly, esbuild apparently outputs ESM bundles with `require` calls still in them (which is invalid).

Until esbuild sorts this out, we have no option but to inject a `createRequire` call and hope for the best.

Fixes #20