### PR TITLE
chore: update lockfile version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tinyexec",
-  "version": "0.0.1",
+  "version": "0.0.0-dev",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tinyexec",
-      "version": "0.0.1",
+      "version": "0.0.0-dev",
       "license": "MIT",
       "devDependencies": {
         "@eslint/js": "^9.0.0",


### PR DESCRIPTION
This got forgotten since we didn't run an `npm i` in previous PRs.