### PR TITLE
fix: do not include timeout by default

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -47,7 +47,7 @@ export interface TinyExec {
 }
 
 const defaultOptions: Partial<Options> = {
-  timeout: 4000,
+  timeout: undefined,
   persist: false
 };
 


### PR DESCRIPTION
fixes https://github.com/tinylibs/tinyexec/issues/29