### PR TITLE
feat: throw on non-zero exit

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ The options object can have the following properties:
 - `persist` - if `true`, the process will continue after the host exits
 - `stdin` - another `Result` can be used as the input to this process
 - `nodeOptions` - any valid options to node's underlying `spawn` function
+- `throwOnError` - if true, non-zero exit codes will throw an error
 
 ### Piping to another process
 

--- a/src/non-zero-exit-error.ts
+++ b/src/non-zero-exit-error.ts
@@ -1,0 +1,20 @@
+import type {Result, Output} from './main.js';
+
+export class NonZeroExitError extends Error {
+  public readonly result: Result;
+  public readonly output?: Output;
+
+  public get exitCode(): number | undefined {
+    if (this.result.exitCode !== null) {
+      return this.result.exitCode;
+    }
+    return undefined;
+  }
+
+  public constructor(result: Result, output?: Output) {
+    super(`Process exited with non-zero status (${result.exitCode})`);
+
+    this.result = result;
+    this.output = output;
+  }
+}


### PR DESCRIPTION
Introduces a new `throwOnError` option which will cause tinyexec to
throw any time a non-zero exit code is encountered.

If the exit code is `null`, we will not throw since it means something
went very wrong anyway (the process is still running and shouldn't be,
since we saw the `close` event by then).

If the exit code is greater than `0`, we will throw a
`NonZeroExitError` which has an `exitCode` property.

For example:

```ts
try {
  await x('foo', [], {throwOnError: true});
} catch (err) {
  if (err instanceof NonZeroExitCode) {
    err.exitCode; // the exit code
    err.result; // the tinyexec process
    err.result.killed; // getters on tinyexec process
  }
}
```

cc @benmccann 