### PR TITLE
Add exitCode to awaited result / Output type

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ const result = await x('ls', ['-l']);
 
 // result.stdout - the stdout as a string
 // result.stderr - the stderr as a string
+// result.exitCode - the process exit code as a number
 ```
 
 You may also iterate over the lines of output via an async loop:
@@ -29,9 +30,9 @@ You may also iterate over the lines of output via an async loop:
 ```ts
 import {x} from 'tinyexec';
 
-const result = x('ls', ['-l']);
+const proc = x('ls', ['-l']);
 
-for await (const line of result) {
+for await (const line of proc) {
   // line will be from stderr/stdout in the order you'd see it in a term
 }
 ```

--- a/src/main.ts
+++ b/src/main.ts
@@ -13,6 +13,7 @@ export {NonZeroExitError};
 export interface Output {
   stderr: string;
   stdout: string;
+  exitCode: number | undefined;
 }
 
 export interface PipeOptions extends Options {}
@@ -238,7 +239,8 @@ export class ExecProcess implements Result {
 
     const result: Output = {
       stderr,
-      stdout
+      stdout,
+      exitCode: this.exitCode
     };
 
     if (

--- a/src/test/main_test.ts
+++ b/src/test/main_test.ts
@@ -144,7 +144,7 @@ if (isWindows) {
 if (!isWindows) {
   test('exec (unix-like)', async (t) => {
     await t.test('times out after defined timeout (ms)', async () => {
-      const proc = x('sleep', ['0.2s'], {timeout: 100});
+      const proc = x('sleep', ['0.2'], {timeout: 100});
       await assert.rejects(async () => {
         await proc;
       });
@@ -160,7 +160,7 @@ if (!isWindows) {
     });
 
     await t.test('kill terminates the process', async () => {
-      const proc = x('sleep', ['5s']);
+      const proc = x('sleep', ['5']);
       const result = proc.kill();
       assert.ok(result);
       assert.ok(proc.killed);
@@ -180,7 +180,7 @@ if (!isWindows) {
 
     await t.test('signal can be used to abort execution', async () => {
       const controller = new AbortController();
-      const proc = x('sleep', ['4s'], {signal: controller.signal});
+      const proc = x('sleep', ['4'], {signal: controller.signal});
       controller.abort();
       const result = await proc;
       assert.ok(proc.aborted);

--- a/src/test/main_test.ts
+++ b/src/test/main_test.ts
@@ -15,8 +15,9 @@ test('exec', async (t) => {
   await t.test('exitCode is set correctly', async () => {
     const proc = x('echo', ['foo']);
     assert.equal(proc.exitCode, undefined);
-    await proc;
+    const result = await proc;
     assert.equal(proc.exitCode, 0);
+    assert.equal(result.exitCode, 0);
   });
 
   await t.test('non-zero exitCode throws when throwOnError=true', async () => {
@@ -107,6 +108,7 @@ if (isWindows) {
 
       assert.equal(result.stderr, '');
       assert.equal(result.stdout, 'foo\n');
+      assert.equal(result.exitCode, 0);
       assert.equal(echoProc.exitCode, 0);
       assert.equal(grepProc.exitCode, 0);
     });
@@ -174,6 +176,7 @@ if (!isWindows) {
 
       assert.equal(result.stderr, '');
       assert.equal(result.stdout, 'foo\n');
+      assert.equal(result.exitCode, 0);
       assert.equal(echoProc.exitCode, 0);
       assert.equal(grepProc.exitCode, 0);
     });


### PR DESCRIPTION
Closes #27

Also: In tests change `sleep 0.2s` invocation to `sleep 0.2`. The former doesn't work on MacOS, the latter works on both MacOS and Linux.