### PR TITLE
docs: add example with args-tokenizer

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,24 @@ proc.aborted; // true
 proc.killed; // true
 ```
 
+### Using with args-tokenizer
+
+[args-tokenizer](https://github.com/TrySound/args-tokenizer) is a lightweight
+library for parsing shell commands with arguments into an argv array.
+
+In this example, it is combined with tinyexec to execute a command from string.
+
+```ts
+import {x} from 'tinyexec';
+import {tokenizeArgs} from 'args-tokenizer';
+
+const commandString = 'echo "Hello, World!"';
+const [command, ...args] = tokenize(commandString);
+const result = await x(command, args);
+
+result.stdout; // Hello, World!
+```
+
 ## API
 
 Calling `x(command[, args])` returns an awaitable `Result` which has the

--- a/README.md
+++ b/README.md
@@ -124,12 +124,11 @@ proc.aborted; // true
 proc.killed; // true
 ```
 
-### Using with args-tokenizer
+### Using with command strings
 
-[args-tokenizer](https://github.com/TrySound/args-tokenizer) is a lightweight
-library for parsing shell commands with arguments into an argv array.
-
-In this example, it is combined with tinyexec to execute a command from string.
+If you need to continue supporting commands as strings (e.g. "command arg0 arg1"),
+you can use [args-tokenizer](https://github.com/TrySound/args-tokenizer),
+a lightweight library for parsing shell command strings into an array.
 
 ```ts
 import {x} from 'tinyexec';


### PR DESCRIPTION
As suggested in https://github.com/tinylibs/tinyexec/issues/42 added example to [args-tokenizer](https://github.com/TrySound/args-tokenizer) for parsing command and argument from strings.