### PR TITLE
feat: migrate to ESM-only build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,3 +39,12 @@ jobs:
           node-version: ${{ matrix.node-version }}
       - run: npm ci
       - run: npm run test
+        if: matrix.node-version != 'latest'
+        # TODO (43081j): remove the following once there's some way to
+        # tell node not to try run typescript sources in a way that doesn't
+        # break <23 node
+      - run: npm run test
+        name: "npm run test (without type stripping)"
+        env:
+          NODE_OPTIONS: --no-experimental-strip-types
+        if: matrix.node-version == 'latest'

--- a/package.json
+++ b/package.json
@@ -5,10 +5,7 @@
   "description": "A minimal library for executing processes in Node",
   "main": "./dist/main.js",
   "files": [
-    "dist",
-    "!dist/node_modules",
-    "!dist/cjs/test",
-    "!dist/esm/test"
+    "dist"
   ],
   "scripts": {
     "build": "npm run build:types && tsup",
@@ -54,10 +51,6 @@
       "import": {
         "types": "./dist/main.d.ts",
         "default": "./dist/main.js"
-      },
-      "require": {
-        "types": "./dist/main.d.cts",
-        "default": "./dist/main.cjs"
       }
     },
     "./package.json": "./package.json"

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -3,7 +3,7 @@ import { defineConfig } from "tsup";
 export default defineConfig({
   entryPoints: ["src/main.ts"],
   outDir: "dist",
-  format: ["esm", "cjs"],
+  format: ["esm"],
   tsconfig: "./tsconfig.json",
   target: "es2022",
   minify: false,


### PR DESCRIPTION
Switches the build setup to only output ESM now that `require(esm)` is a thing.