### PR TITLE
chore: update `exports` map in `package.json`

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,10 +48,8 @@
   },
   "exports": {
     ".": {
-      "import": {
-        "types": "./dist/main.d.ts",
-        "default": "./dist/main.js"
-      }
+      "types": "./dist/main.d.ts",
+      "default": "./dist/main.js"
     },
     "./package.json": "./package.json"
   },


### PR DESCRIPTION
With only `import` in the package.json `exports` map, it prevents `require('tinyexec')` from working even on Node.js 22/23.

This can be fixed by adding `require` as well, or simply removing `imports` constraints. The PR implements the latter one.

cc @43081j 