### PR TITLE
chore: set engine constraint

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,9 @@
         "tsdown": "^0.9.9",
         "typescript": "^5.4.5",
         "typescript-eslint": "^7.7.0"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {

--- a/package.json
+++ b/package.json
@@ -4,6 +4,9 @@
   "type": "module",
   "description": "A minimal library for executing processes in Node",
   "main": "./dist/main.js",
+  "engines": {
+    "node": ">=18"
+  },
   "files": [
     "dist"
   ],


### PR DESCRIPTION
We're already requiring node 18 and above implicitly - this just makes
it explicit.

Fixes #55 
