### PR TITLE
feat: Support `Result | ExecProcess | string` for `options.stdin` 

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,11 +58,23 @@ await x('ls', [], {
 The options object can have the following properties:
 
 - `signal` - an `AbortSignal` to allow aborting of the execution
-- `timeout` - time in milliseconds at which the process will be forceably killed
+- `timeout` - time in milliseconds at which the process will be forcibly killed
 - `persist` - if `true`, the process will continue after the host exits
-- `stdin` - another `Result` can be used as the input to this process
+- `stdin` - `string` or another `Result` that will be used as the input to the process
 - `nodeOptions` - any valid options to node's underlying `spawn` function
 - `throwOnError` - if true, non-zero exit codes will throw an error
+
+### Passing a string to stdin
+
+You can pass a string to `stdin`, which is useful for whitespace-sensitive values and for secrets you shouldn’t be exposed in shell history:
+
+```ts
+const result = await x('gh', ['auth', 'login', '--with-token'], {
+  stdin: process.env.GITHUB_TOKEN
+});
+
+console.log(result.exitCode);
+```
 
 ### Piping to another process
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -62,7 +62,7 @@ export interface Options extends CommonOptions {
   signal: AbortSignal;
   nodeOptions: SpawnOptions;
   persist: boolean;
-  stdin: ExecProcess;
+  stdin: Result | ExecProcess | string;
 }
 
 export interface SyncOptions extends CommonOptions {
@@ -257,8 +257,10 @@ export class ExecProcess implements Result {
 
     await this._processClosed;
 
-    if (this._options?.stdin) {
-      await this._options.stdin;
+    const {stdin} = this._options;
+
+    if (stdin && typeof stdin !== 'string') {
+      await stdin;
     }
 
     proc.removeAllListeners();
@@ -345,10 +347,13 @@ export class ExecProcess implements Result {
     handle.once('error', this._onError);
     handle.once('close', this._onClose);
 
-    if (options.stdin !== undefined && handle.stdin && options.stdin.process) {
-      const {stdout} = options.stdin.process;
-      if (stdout) {
-        stdout.pipe(handle.stdin);
+    if (handle.stdin) {
+      const {stdin} = options;
+
+      if (typeof stdin === 'string') {
+        handle.stdin.end(stdin);
+      } else {
+        stdin?.process?.stdout?.pipe(handle.stdin);
       }
     }
   }

--- a/src/test/main_test.ts
+++ b/src/test/main_test.ts
@@ -1,4 +1,4 @@
-import {x, xSync, NonZeroExitError} from '../main.js';
+import {x, xSync, ExecProcess, NonZeroExitError} from '../main.js';
 import {describe, test, expect} from 'vitest';
 import os from 'node:os';
 
@@ -60,6 +60,58 @@ describe('exec (async)', () => {
       await proc;
     }).rejects.toThrow(NonZeroExitError);
     expect(proc.exitCode).toBe(1);
+  });
+
+  test('supports stdin passed as a string', async () => {
+    let result = await x('node', ['-e', 'process.stdin.pipe(process.stdout)'], {
+      stdin: 'foo\nbar'
+    });
+
+    expect(result.stdout).toBe('foo\nbar');
+    expect(result.stderr).toBe('');
+    expect(result.exitCode).toBe(0);
+
+    // Ensuring that empty string doesn’t cause issues
+    result = await x(
+      'node',
+      ['-e', "process.stdout.write(String(fs.readFileSync(0,'utf8').length))"],
+      {stdin: ''}
+    );
+
+    expect(result.stdout).toBe('0');
+    expect(result.stderr).toBe('');
+    expect(result.exitCode).toBe(0);
+  });
+
+  test('supports stdin passed as another process (Result)', async () => {
+    const proc = x('node', ['-e', "process.stdout.write('foo\\nbar')"]);
+    const result = await x(
+      'node',
+      ['-e', 'process.stdin.pipe(process.stdout)'],
+      {stdin: proc}
+    );
+
+    expect(result.stdout).toBe('foo\nbar');
+    expect(result.stderr).toBe('');
+    expect(result.exitCode).toBe(0);
+  });
+
+  test('supports stdin passed as another process (ExecProcess)', async () => {
+    const proc = new ExecProcess('node', [
+      '-e',
+      "process.stdout.write('foo\\nbar')"
+    ]);
+    proc.spawn();
+
+    const result = await x(
+      'node',
+      ['-e', 'process.stdin.pipe(process.stdout)'],
+      {stdin: proc}
+    );
+
+    expect(result.stdout).toBe('foo\nbar');
+    expect(result.stderr).toBe('');
+    expect(result.exitCode).toBe(0);
   });
 });
 


### PR DESCRIPTION
Resolves #104.