### PR TITLE
fix: install npm twice to make publish work

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -29,6 +29,7 @@ jobs:
           node-version: 22.x
           registry-url: 'https://registry.npmjs.org'
           cache: 'npm'
+      - run: npm install -g npm@~11.10.0 # Work-around for https://github.com/npm/cli/issues/9151#issuecomment-4131466208
       - run: npm install -g npm@latest
       - run: npm ci
       - run: npm version ${TAG_NAME} --git-tag-version=false


### PR DESCRIPTION
The npm team somehow managed to break npm unless you install an older
version before the latest. Good times.
