### PR TITLE
feat: accept readonly string[] for args parameters

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -70,7 +70,11 @@ export interface SyncOptions extends CommonOptions {
 }
 
 export interface TinyExec {
-  (command: string, args?: readonly string[], options?: Partial<Options>): Result;
+  (
+    command: string,
+    args?: readonly string[],
+    options?: Partial<Options>
+  ): Result;
 }
 
 const defaultOptions: Partial<Options> = {

--- a/src/main.ts
+++ b/src/main.ts
@@ -41,7 +41,7 @@ export interface OutputApi extends AsyncIterable<string>, CommonOutputApi {
 
   pipe(
     command: string,
-    args?: string[],
+    args?: readonly string[],
     options?: Partial<PipeOptions>
   ): Result;
   kill(signal?: KillSignal): boolean;
@@ -70,7 +70,7 @@ export interface SyncOptions extends CommonOptions {
 }
 
 export interface TinyExec {
-  (command: string, args?: string[], options?: Partial<Options>): Result;
+  (command: string, args?: readonly string[], options?: Partial<Options>): Result;
 }
 
 const defaultOptions: Partial<Options> = {
@@ -88,10 +88,10 @@ const defaultNodeOptions: SpawnOptions = {
 
 function normaliseCommandAndArgs(
   command: string,
-  args?: string[]
+  args?: readonly string[]
 ): {
   command: string;
-  args: string[];
+  args: readonly string[];
 } {
   const normalisedPath = normalizePath(command);
   const normalisedArgs = args ?? [];
@@ -141,7 +141,7 @@ export class ExecProcess implements Result {
   protected _aborted: boolean = false;
   protected _options: Partial<Options>;
   protected _command: string;
-  protected _args: string[];
+  protected _args: readonly string[];
   protected _resolveClose?: () => void;
   protected _processClosed: Promise<void>;
   protected _thrownError?: Error;
@@ -163,7 +163,7 @@ export class ExecProcess implements Result {
 
   public constructor(
     command: string,
-    args?: string[],
+    args?: readonly string[],
     options?: Partial<Options>
   ) {
     this._options = {
@@ -191,7 +191,7 @@ export class ExecProcess implements Result {
 
   public pipe(
     command: string,
-    args?: string[],
+    args?: readonly string[],
     options?: Partial<PipeOptions>
   ): Result {
     return exec(command, args, {
@@ -386,7 +386,7 @@ export class ExecProcess implements Result {
 
 export function xSync(
   command: string,
-  args?: string[],
+  args?: readonly string[],
   options?: Partial<SyncOptions>
 ): SyncResult {
   const opts = {...defaultSyncOptions, ...options};

--- a/src/types/cross-spawn.d.ts
+++ b/src/types/cross-spawn.d.ts
@@ -3,7 +3,7 @@ import type {SpawnOptions} from 'child_process';
 declare module 'cross-spawn' {
   export function _parse(
     file: string,
-    args: string[],
+    args: readonly string[],
     options?: SpawnOptions
   ): {command: string; args: string[]; options: SpawnOptions};
 }


### PR DESCRIPTION
## Summary

Change all `args` parameters from `string[]` to `readonly string[]`, so callers can pass `readonly string[]` without a type error.

```ts
import { x } from 'tinyexec';

function execLs(args: ReadonlyArray<string>) {
    return x('ls', args); // Error: Argument of type 'readonly string[]' is not assignable to parameter of type 'string[]'.
}

execLs(['-l']);
```

## Comparison

Other related libraries already use `readonly string[]` for args:
- cross-spawn - [`args` is `readonly string[]`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/a2a1b7a379e5d9eb5887c405a84d8e66c5cec4d5/types/cross-spawn/index.d.ts#L26)
- execa - [`arguments` is `readonly string[]`](https://github.com/sindresorhus/execa/blob/f3a2e8481a1e9138de3895827895c834078b9456/types/methods/main-async.d.ts#L373)
