### PR TITLE
feat: add `nodePath` flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ The options object can have the following properties:
 - `stdin` - `string` or another `Result` that will be used as the input to the process
 - `nodeOptions` - any valid options to node's underlying `spawn` function
 - `throwOnError` - if true, non-zero exit codes will throw an error
+- `nodePath` - if `false`, `node_modules/.bin` directories and the current node executable's directory will not be prepended to `PATH` (defaults to `true`)
 
 ### Passing a string to stdin
 
@@ -122,6 +123,13 @@ await x('eslint', ['.']);
 ```
 
 In this example, `eslint` will come from the locally installed `node_modules`.
+
+If you'd rather not have `node_modules/.bin` (or the directory of the current
+`node` executable) prepended to `PATH`, pass `nodePath: false`:
+
+```ts
+await x('eslint', ['.'], {nodePath: false});
+```
 
 ### Using an abort signal
 

--- a/src/env.ts
+++ b/src/env.ts
@@ -54,11 +54,20 @@ function addNodeBinToPath(cwd: string, path: EnvPathInfo): EnvPathInfo {
   return {key: path.key, value: newPath};
 }
 
-export function computeEnv(cwd: string, env?: EnvLike): EnvLike {
+export function computeEnv(
+  cwd: string,
+  env?: EnvLike,
+  nodePath: boolean = true
+): EnvLike {
   const envWithDefault = {
     ...process.env,
     ...env
   };
+
+  if (!nodePath) {
+    return envWithDefault;
+  }
+
   const envPathInfo = addNodeBinToPath(cwd, getPathFromEnv(envWithDefault));
   envWithDefault[envPathInfo.key] = envPathInfo.value;
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -55,6 +55,7 @@ export type SyncResult = Output & OutputApiSync;
 export interface CommonOptions {
   timeout: number;
   throwOnError: boolean;
+  nodePath: boolean;
 }
 
 export interface Options extends CommonOptions {
@@ -310,7 +311,7 @@ export class ExecProcess implements Result {
       nodeOptions.signal = combineSignals(signals);
     }
 
-    nodeOptions.env = computeEnv(cwd, nodeOptions.env);
+    nodeOptions.env = computeEnv(cwd, nodeOptions.env, options.nodePath);
 
     const crossResult = normalizeSpawnCommand(
       this._command,
@@ -388,7 +389,7 @@ export function xSync(
     nodeOptions.timeout = opts.timeout;
   }
 
-  nodeOptions.env = computeEnv(cwd, nodeOptions.env);
+  nodeOptions.env = computeEnv(cwd, nodeOptions.env, opts.nodePath);
 
   const crossResult = normalizeSpawnCommand(command, args ?? [], nodeOptions);
 

--- a/src/test/env_test.ts
+++ b/src/test/env_test.ts
@@ -70,6 +70,29 @@ describe('computeEnv', async () => {
     }
   });
 
+  test('does not add node binaries when nodePath is false', () => {
+    const originalPath = path.join(pathSep, 'usr', 'local', 'bin');
+    const cwd = path.resolve(pathSep, 'one', 'two', 'three');
+
+    const env = computeEnv(cwd, {PATH: originalPath}, false);
+
+    expect(env[pathKey]).toBe(originalPath);
+    expect(env[pathKey]!.includes(`node_modules${pathSep}.bin`)).toBe(false);
+  });
+
+  test('adds node binaries when nodePath is true (default)', () => {
+    const originalPath = path.join(pathSep, 'usr', 'local', 'bin');
+    const cwd = path.resolve(pathSep, 'one', 'two', 'three');
+
+    const explicit = computeEnv(cwd, {PATH: originalPath}, true);
+    const implicit = computeEnv(cwd, {PATH: originalPath});
+
+    expect(explicit[pathKey]).toBe(implicit[pathKey]);
+    expect(explicit[pathKey]!.includes(`node_modules${pathSep}.bin`)).toBe(
+      true
+    );
+  });
+
   test('prepends local node_modules/.bin and directory of node executable to PATH', () => {
     /** The original variable is just `PATH=/usr/local/bin` */
     const originalPath = path.join(pathSep, 'usr', 'local', 'bin');


### PR DESCRIPTION
This flag allows you to disable prepending of `node_modules/.bin` and
the current node binary's directory.

Useful when you want to explicitly set an exact `PATH` and have it
untouched.
