### PR TITLE
fix: correct shebang regex

### DIFF
--- a/src/normalize.ts
+++ b/src/normalize.ts
@@ -11,7 +11,7 @@ import {getPathFromEnv} from './env.js';
 
 // See http://www.robvanderwoude.com/escapechars.php
 const metaCharsRegExp = /([()\][%!^"`<>&|;, *?])/g;
-const shebangRegExp = /^#!\s*(.+)$/;
+const shebangRegExp = /^#!\s*(.+)/;
 const isWindowsExecutableRegExp = /\.(?:com|exe)$/i;
 const isNodeModulesCmdRegExp = /node_modules[\\/]\.bin[\\/][^\\/]+\.cmd$/i;
 const isWindows = process.platform === 'win32';

--- a/src/test/normalize_test.ts
+++ b/src/test/normalize_test.ts
@@ -7,7 +7,7 @@ import {fileURLToPath} from 'node:url';
 const isWindows = os.platform() === 'win32';
 const fixturesPath = path.join(
   path.dirname(fileURLToPath(import.meta.url)),
-  '../test/fixtures'
+  '../../test/fixtures'
 );
 const cwd = process.cwd();
 
@@ -59,6 +59,16 @@ describe('normalizeSpawnCommand', () => {
         args: ['/d', '/s', '/c', `"${relativePath}"`],
         options: {windowsVerbatimArguments: true}
       });
+    });
+
+    test('detects shebang and rewrites command to interpreter', () => {
+      const scriptPath = path.join(fixturesPath, 'shebang_script.js');
+      const normalized = normalizeSpawnCommand(scriptPath, []);
+
+      // where resolves to where.exe (always a .exe in System32, never a
+      // shim), so the cmd.exe wrapping branch is skipped
+      expect(normalized.command).toBe('where');
+      expect(normalized.args).toEqual([scriptPath]);
     });
 
     test('handles relative commands without extension', () => {

--- a/test/fixtures/shebang_script.js
+++ b/test/fixtures/shebang_script.js
@@ -1,0 +1,2 @@
+#!where
+not a real script, just used to verify shebang parsing


### PR DESCRIPTION
We were incorrectly looking for the end of the input, which meant most
shebangs were not being matched :eyes:
