### PR TITLE
fix: throw NonZeroExitError when process is killed by signal

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -32,6 +32,7 @@ export interface CommonOutputApi {
   get pid(): number | undefined;
   get killed(): boolean;
   get exitCode(): number | undefined;
+  get signalCode(): string | null;
 }
 
 export interface OutputApi extends AsyncIterable<string>, CommonOutputApi {
@@ -149,6 +150,10 @@ export class ExecProcess implements Result {
     return undefined;
   }
 
+  public get signalCode(): string | null {
+    return this._process?.signalCode ?? null;
+  }
+
   public constructor(
     command: string,
     args?: readonly string[],
@@ -224,8 +229,8 @@ export class ExecProcess implements Result {
 
     if (
       this._options?.throwOnError &&
-      this.exitCode !== 0 &&
-      this.exitCode !== undefined
+      ((this.exitCode !== 0 && this.exitCode !== undefined) ||
+        this.signalCode != null)
     ) {
       throw new NonZeroExitError(this, undefined, this._command, this._args);
     }
@@ -265,8 +270,8 @@ export class ExecProcess implements Result {
 
     if (
       this._options.throwOnError &&
-      this.exitCode !== 0 &&
-      this.exitCode !== undefined
+      ((this.exitCode !== 0 && this.exitCode !== undefined) ||
+        this.signalCode != null)
     ) {
       throw new NonZeroExitError(this, result, this._command, this._args);
     }
@@ -406,13 +411,17 @@ export function xSync(
   const stdout = spawnResult.stdout?.toString() ?? '';
   const stderr = spawnResult.stderr?.toString() ?? '';
   const exitCode = spawnResult.status ?? undefined;
-  const killed = spawnResult.signal != null;
+  const signalCode = spawnResult.signal ?? null;
+  const killed = signalCode != null;
 
   const result: SyncResult = {
     stdout,
     stderr,
     get exitCode() {
       return exitCode;
+    },
+    get signalCode() {
+      return signalCode;
     },
     get pid() {
       return spawnResult.pid;
@@ -430,7 +439,10 @@ export function xSync(
     }
   };
 
-  if (opts.throwOnError && exitCode !== 0 && exitCode !== undefined) {
+  if (
+    opts.throwOnError &&
+    ((exitCode !== 0 && exitCode !== undefined) || signalCode != null)
+  ) {
     throw new NonZeroExitError(
       result,
       {

--- a/src/main.ts
+++ b/src/main.ts
@@ -230,7 +230,7 @@ export class ExecProcess implements Result {
     if (
       this._options?.throwOnError &&
       ((this.exitCode !== 0 && this.exitCode !== undefined) ||
-        this.signalCode != null)
+        this.signalCode !== null)
     ) {
       throw new NonZeroExitError(this, undefined, this._command, this._args);
     }
@@ -271,7 +271,7 @@ export class ExecProcess implements Result {
     if (
       this._options.throwOnError &&
       ((this.exitCode !== 0 && this.exitCode !== undefined) ||
-        this.signalCode != null)
+        this.signalCode !== null)
     ) {
       throw new NonZeroExitError(this, result, this._command, this._args);
     }
@@ -412,7 +412,7 @@ export function xSync(
   const stderr = spawnResult.stderr?.toString() ?? '';
   const exitCode = spawnResult.status ?? undefined;
   const signalCode = spawnResult.signal ?? null;
-  const killed = signalCode != null;
+  const killed = signalCode !== null;
 
   const result: SyncResult = {
     stdout,
@@ -441,7 +441,7 @@ export function xSync(
 
   if (
     opts.throwOnError &&
-    ((exitCode !== 0 && exitCode !== undefined) || signalCode != null)
+    ((exitCode !== 0 && exitCode !== undefined) || signalCode !== null)
   ) {
     throw new NonZeroExitError(
       result,

--- a/src/non-zero-exit-error.ts
+++ b/src/non-zero-exit-error.ts
@@ -27,8 +27,8 @@ export class NonZeroExitError extends Error {
     const exitCode = result.exitCode ?? 1;
 
     super(
-      result.signalCode != null
-        ? `${target} was killed with signal ${result.signalCode}`
+      result.signalCode !== null
+        ? `${target} was killed by the signal ${result.signalCode}`
         : `${target} exited with a non-zero status (${exitCode})`
     );
     this.exitCode = exitCode;

--- a/src/non-zero-exit-error.ts
+++ b/src/non-zero-exit-error.ts
@@ -3,6 +3,10 @@ import type {Output, CommonOutputApi} from './main.js';
 export class NonZeroExitError extends Error {
   public readonly exitCode: number;
 
+  public get signalCode(): string | null {
+    return this.result.signalCode;
+  }
+
   public constructor(
     public readonly result: CommonOutputApi,
     public readonly output?: Output,
@@ -22,7 +26,11 @@ export class NonZeroExitError extends Error {
     // we default to 1 in case.
     const exitCode = result.exitCode ?? 1;
 
-    super(`${target} exited with a non-zero status (${exitCode})`);
+    super(
+      result.signalCode != null
+        ? `${target} was killed with signal ${result.signalCode}`
+        : `${target} exited with a non-zero status (${exitCode})`
+    );
     this.exitCode = exitCode;
 
     // `result` is usually passed the entire instance of the exec process

--- a/src/test/main_test.ts
+++ b/src/test/main_test.ts
@@ -95,29 +95,10 @@ describe('exec (async)', () => {
     expect(proc.exitCode).toBe(1);
   });
 
-  test('throws when throwOnError=true and process is killed by signal', async () => {
-    const proc = x(
-      'node',
-      ['-e', 'process.kill(process.pid, "SIGTERM")'],
-      {throwOnError: true}
-    );
-    try {
-      await proc;
-      expect.fail('Expected to throw');
-    } catch (err) {
-      expect.assert(err instanceof NonZeroExitError);
-      expect(err.signalCode).toBe('SIGTERM');
-    }
-    expect(proc.exitCode).toBeUndefined();
-    expect(proc.signalCode).toBe('SIGTERM');
-  });
-
   test('async iterator throws when throwOnError=true and process is killed by signal', async () => {
-    const proc = x(
-      'node',
-      ['-e', 'process.kill(process.pid, "SIGTERM")'],
-      {throwOnError: true}
-    );
+    const proc = x('node', ['-e', 'process.kill(process.pid, "SIGTERM")'], {
+      throwOnError: true
+    });
     await expect(async () => {
       for await (const _line of proc) {
         // consume iterator
@@ -189,14 +170,6 @@ describe('exec (sync)', () => {
         'The command `node -e "process.exit(1);"` exited with a non-zero status (1)'
       );
     }
-  });
-
-  test('throws when throwOnError=true and process is killed by signal', () => {
-    expect(() => {
-      xSync('node', ['-e', 'process.kill(process.pid, "SIGTERM")'], {
-        throwOnError: true
-      });
-    }).toThrow(NonZeroExitError);
   });
 });
 
@@ -303,6 +276,24 @@ if (isWindows) {
         fs.rmSync(dir, {recursive: true, force: true});
       }
     });
+
+    test('throws when throwOnError=true and process is killed by signal', async () => {
+      const proc = x('node', ['-e', 'process.kill(process.pid, "SIGTERM")'], {
+        throwOnError: true
+      });
+      try {
+        await proc;
+        expect.fail('Expected to throw');
+      } catch (err) {
+        expect.assert(err instanceof NonZeroExitError);
+        expect(err.message).toBe(
+          'The command `node -e "process.kill(process.pid, \\"SIGTERM\\")"` exited with a non-zero status (1)'
+        );
+        expect(err.signalCode).toBe(null);
+      }
+      expect(proc.exitCode).toBe(1);
+      expect(proc.signalCode).toBe(null);
+    });
   });
 
   describe('exec (windows) (sync)', () => {
@@ -340,6 +331,20 @@ if (isWindows) {
         expect(result.stdout).toBe('local\r\n');
       } finally {
         fs.rmSync(dir, {recursive: true, force: true});
+      }
+    });
+
+    test('killed by signal throws when throwOnError=true', () => {
+      try {
+        xSync('node', ['-e', 'process.kill(process.pid, "SIGTERM")'], {
+          throwOnError: true
+        });
+        expect.fail('Expected to throw');
+      } catch (err) {
+        expect(err instanceof NonZeroExitError).ok;
+        expect((err as NonZeroExitError).message).toBe(
+          'The command `node -e "process.kill(process.pid, \\"SIGTERM\\")"` exited with a non-zero status (1)'
+        );
       }
     });
   });
@@ -498,6 +503,24 @@ if (!isWindows) {
         fs.rmSync(dir, {recursive: true, force: true});
       }
     });
+
+    test('throws when throwOnError=true and process is killed by signal', async () => {
+      const proc = x('node', ['-e', 'process.kill(process.pid, "SIGTERM")'], {
+        throwOnError: true
+      });
+      try {
+        await proc;
+        expect.fail('Expected to throw');
+      } catch (err) {
+        expect.assert(err instanceof NonZeroExitError);
+        expect(err.message).toBe(
+          'The command `node -e "process.kill(process.pid, \\"SIGTERM\\")"` was killed by the signal SIGTERM'
+        );
+        expect(err.signalCode).toBe('SIGTERM');
+      }
+      expect(proc.exitCode).toBeUndefined();
+      expect(proc.signalCode).toBe('SIGTERM');
+    });
   });
 
   describe('exec (unix-like) (sync)', () => {
@@ -538,6 +561,20 @@ if (!isWindows) {
         expect(result.stdout).toBe('local\n');
       } finally {
         fs.rmSync(dir, {recursive: true, force: true});
+      }
+    });
+
+    test('killed by signal throws when throwOnError=true', () => {
+      try {
+        xSync('node', ['-e', 'process.kill(process.pid, "SIGTERM")'], {
+          throwOnError: true
+        });
+        expect.fail('Expected to throw');
+      } catch (err) {
+        expect(err instanceof NonZeroExitError).ok;
+        expect((err as NonZeroExitError).message).toBe(
+          'The command `node -e "process.kill(process.pid, \\"SIGTERM\\")"` was killed by the signal SIGTERM'
+        );
       }
     });
   });

--- a/src/test/main_test.ts
+++ b/src/test/main_test.ts
@@ -95,6 +95,36 @@ describe('exec (async)', () => {
     expect(proc.exitCode).toBe(1);
   });
 
+  test('throws when throwOnError=true and process is killed by signal', async () => {
+    const proc = x(
+      'node',
+      ['-e', 'process.kill(process.pid, "SIGTERM")'],
+      {throwOnError: true}
+    );
+    try {
+      await proc;
+      expect.fail('Expected to throw');
+    } catch (err) {
+      expect.assert(err instanceof NonZeroExitError);
+      expect(err.signalCode).toBe('SIGTERM');
+    }
+    expect(proc.exitCode).toBeUndefined();
+    expect(proc.signalCode).toBe('SIGTERM');
+  });
+
+  test('async iterator throws when throwOnError=true and process is killed by signal', async () => {
+    const proc = x(
+      'node',
+      ['-e', 'process.kill(process.pid, "SIGTERM")'],
+      {throwOnError: true}
+    );
+    await expect(async () => {
+      for await (const _line of proc) {
+        // consume iterator
+      }
+    }).rejects.toThrow(NonZeroExitError);
+  });
+
   test('supports stdin passed as a string', async () => {
     let result = await x('node', ['-e', 'process.stdin.pipe(process.stdout)'], {
       stdin: 'foo\nbar'
@@ -159,6 +189,14 @@ describe('exec (sync)', () => {
         'The command `node -e "process.exit(1);"` exited with a non-zero status (1)'
       );
     }
+  });
+
+  test('throws when throwOnError=true and process is killed by signal', () => {
+    expect(() => {
+      xSync('node', ['-e', 'process.kill(process.pid, "SIGTERM")'], {
+        throwOnError: true
+      });
+    }).toThrow(NonZeroExitError);
   });
 });
 


### PR DESCRIPTION
## Summary

When a child process is killed by a signal (SIGABRT, SIGKILL, SIGTERM, etc.), `throwOnError: true` silently resolves instead of throwing `NonZeroExitError`.

**Root cause:** When a process dies by signal, Node.js sets `child.exitCode = null` and `child.signalCode` to the signal name. The `exitCode` getter returns `undefined` for `null`, and the `throwOnError` check excludes `undefined` — so signal-killed processes slip through. Same flaw exists in `xSync`.

## Changes

- Add `signalCode` to `CommonOutputApi` interface and `ExecProcess` getter
- Fix `throwOnError` in `_waitForOutput` and async iterator to throw when `signalCode != null`
- Fix `xSync` throwOnError to also check `signalCode`
- Update `NonZeroExitError` message to `"Process was killed with signal SIGTERM"` for signal deaths; expose `signalCode` getter
- Add regression tests for async and sync signal-kill paths

Fixes #144