### PR TITLE
fix: disable code minification

### DIFF
--- a/tsdown.config.ts
+++ b/tsdown.config.ts
@@ -5,13 +5,4 @@ export default defineConfig({
   target: 'es2022',
   clean: true,
   dts: true,
-  outputOptions: {
-    minify: {
-      mangle: true,
-      compress: false,
-      codegen: {
-        removeWhitespace: false
-      }
-    }
-  }
 });


### PR DESCRIPTION
This doesn't change the dist code much, because the only minification it did before was renaming identifiers, but I think it's better to not minify at all.

One benefit of this is you get better error messages:
```
                if (this._options.throwOnError && this.exitCode !== 0 && this.exitCode !== void 0) throw new NonZeroExitError(this, result);
                                                                                                         ^

NonZeroExitError: The process exited with a non-zero status (128)
    at ExecProcess._waitForOutput (file:///Users/bjorn/Work/oss/tinyexec/dist/main.mjs:291:92)
    at async file:///Users/bjorn/Work/oss/tinyexec/test.mjs:3:1 {
```

Before:
```
                if (this._options.throwOnError && this.exitCode !== 0 && this.exitCode !== void 0) throw new k(this, i);
                                                                                                         ^

k [Error]: The process exited with a non-zero status (128)
    at I._waitForOutput (file:///Users/bjorn/Work/oss/tinyexec/dist/main.mjs:291:92)
    at async file:///Users/bjorn/Work/oss/tinyexec/test.mjs:3:1 {
```

Note the `NonZeroExitError:` part