### PR TITLE
feat: improve NonZeroExitError message

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -227,7 +227,7 @@ export class ExecProcess implements Result {
       this.exitCode !== 0 &&
       this.exitCode !== undefined
     ) {
-      throw new NonZeroExitError(this);
+      throw new NonZeroExitError(this, undefined, this._command, this._args);
     }
   }
 
@@ -268,7 +268,7 @@ export class ExecProcess implements Result {
       this.exitCode !== 0 &&
       this.exitCode !== undefined
     ) {
-      throw new NonZeroExitError(this, result);
+      throw new NonZeroExitError(this, result, this._command, this._args);
     }
 
     return result;
@@ -431,7 +431,16 @@ export function xSync(
   };
 
   if (opts.throwOnError && exitCode !== 0 && exitCode !== undefined) {
-    throw new NonZeroExitError(result, result);
+    throw new NonZeroExitError(
+      result,
+      {
+        stdout: result.stdout,
+        stderr: result.stderr,
+        exitCode: result.exitCode
+      },
+      command,
+      args
+    );
   }
 
   return result;

--- a/src/non-zero-exit-error.ts
+++ b/src/non-zero-exit-error.ts
@@ -12,7 +12,7 @@ export class NonZeroExitError extends Error {
     let target = 'The process';
     if (command) {
       const fullCommand = args?.length
-        ? `${command} ${args.map((a) => (a.includes(' ') ? JSON.stringify(a) : a)).join(' ')}`
+        ? `${command} ${args.map((a) => (/[ "'`()]/.test(a) ? JSON.stringify(a) : a)).join(' ')}`
         : command;
       target = `The command \`${fullCommand}\``;
     }

--- a/src/non-zero-exit-error.ts
+++ b/src/non-zero-exit-error.ts
@@ -17,17 +17,17 @@ export class NonZeroExitError extends Error {
       target = `The command \`${fullCommand}\``;
     }
 
-    // This error is normally only created when the exit code is non-zero, so it
-    // must exist here. However, due to types compatibility, we accept it being
-    // nullable and default to 1 in case.
+    // This error is normally only created when the exit code is non-nullable
+    // and non-zero, so it must exist here. However, due to types compatibility,
+    // we default to 1 in case.
     const exitCode = result.exitCode ?? 1;
 
     super(`${target} exited with a non-zero status (${exitCode})`);
     this.exitCode = exitCode;
 
-    // `result` is sometimes passed the entire child process object, which
-    // results in very large logs as it used to be typed `Result`. However,
-    // we don't manually subset it for now to keep compatibility.
+    // `result` is usually passed the entire instance of the exec process
+    // depending on the exec API so that handlers can interact with it fully.
+    // As such, its log can be very large so we hide it by making it non-enumerable.
     Object.defineProperty(this, 'result', {
       enumerable: false,
       writable: false,

--- a/src/non-zero-exit-error.ts
+++ b/src/non-zero-exit-error.ts
@@ -1,17 +1,37 @@
 import type {Output, CommonOutputApi} from './main.js';
 
 export class NonZeroExitError extends Error {
-  public get exitCode(): number | undefined {
-    if (this.result.exitCode !== null) {
-      return this.result.exitCode;
-    }
-    return undefined;
-  }
+  public readonly exitCode: number;
 
   public constructor(
     public readonly result: CommonOutputApi,
-    public readonly output?: Output
+    public readonly output?: Output,
+    command?: string,
+    args?: readonly string[]
   ) {
-    super(`Process exited with non-zero status (${result.exitCode})`);
+    let target = 'The process';
+    if (command) {
+      const fullCommand = args?.length
+        ? `${command} ${args.map((a) => (a.includes(' ') ? JSON.stringify(a) : a)).join(' ')}`
+        : command;
+      target = `The command \`${fullCommand}\``;
+    }
+
+    // This error is normally only created when the exit code is non-zero, so it
+    // must exist here. However, due to types compatibility, we accept it being
+    // nullable and default to 1 in case.
+    const exitCode = result.exitCode ?? 1;
+
+    super(`${target} exited with a non-zero status (${exitCode})`);
+    this.exitCode = exitCode;
+
+    // `result` is sometimes passed the entire child process object, which
+    // results in very large logs as it used to be typed `Result`. However,
+    // we don't manually subset it for now to keep compatibility.
+    Object.defineProperty(this, 'result', {
+      enumerable: false,
+      writable: false,
+      configurable: false
+    });
   }
 }

--- a/src/test/main_test.ts
+++ b/src/test/main_test.ts
@@ -68,7 +68,7 @@ describe('exec (async)', () => {
       expect.assert(err instanceof NonZeroExitError);
       expect(err.exitCode).toBe(1);
       expect(err.message).toBe(
-        'The command `node -e process.exit(1);` exited with a non-zero status (1)'
+        'The command `node -e "process.exit(1);"` exited with a non-zero status (1)'
       );
     }
     expect(proc.exitCode).toBe(1);
@@ -88,7 +88,7 @@ describe('exec (async)', () => {
       expect.assert(err instanceof NonZeroExitError);
       expect(err.exitCode).toBe(1);
       expect(err.message).toBe(
-        'The command `node -e process.exit(1);` exited with a non-zero status (1)'
+        'The command `node -e "console.log(\'foo\'); process.exit(1);"` exited with a non-zero status (1)'
       );
     }
     expect(lines).toEqual(['foo']);
@@ -156,7 +156,7 @@ describe('exec (sync)', () => {
     } catch (err) {
       expect(err instanceof NonZeroExitError).ok;
       expect((err as NonZeroExitError).message).toBe(
-        '`node -e process.exit(1);` exited with a non-zero status (1)'
+        'The command `node -e "process.exit(1);"` exited with a non-zero status (1)'
       );
     }
   });

--- a/src/test/main_test.ts
+++ b/src/test/main_test.ts
@@ -61,9 +61,16 @@ describe.each(variants)('exec ($name)', ({x, isAsync}) => {
 describe('exec (async)', () => {
   test('non-zero exitCode throws when throwOnError=true', async () => {
     const proc = x('node', ['-e', 'process.exit(1);'], {throwOnError: true});
-    await expect(async () => {
+    try {
       await proc;
-    }).rejects.toThrow(NonZeroExitError);
+      expect.fail('Expected to throw');
+    } catch (err) {
+      expect.assert(err instanceof NonZeroExitError);
+      expect(err.exitCode).toBe(1);
+      expect(err.message).toBe(
+        'The command `node -e process.exit(1);` exited with a non-zero status (1)'
+      );
+    }
     expect(proc.exitCode).toBe(1);
   });
 
@@ -72,11 +79,18 @@ describe('exec (async)', () => {
       throwOnError: true
     });
     const lines: string[] = [];
-    await expect(async () => {
+    try {
       for await (const line of proc) {
         lines.push(line);
       }
-    }).rejects.toThrow(NonZeroExitError);
+      expect.fail('Expected to throw');
+    } catch (err) {
+      expect.assert(err instanceof NonZeroExitError);
+      expect(err.exitCode).toBe(1);
+      expect(err.message).toBe(
+        'The command `node -e process.exit(1);` exited with a non-zero status (1)'
+      );
+    }
     expect(lines).toEqual(['foo']);
     expect(proc.exitCode).toBe(1);
   });
@@ -136,9 +150,15 @@ describe('exec (async)', () => {
 
 describe('exec (sync)', () => {
   test('non-zero exitCode throws when throwOnError=true', () => {
-    expect(() => {
+    try {
       xSync('node', ['-e', 'process.exit(1);'], {throwOnError: true});
-    }).toThrow(NonZeroExitError);
+      expect.fail('Expected to throw');
+    } catch (err) {
+      expect(err instanceof NonZeroExitError).ok;
+      expect((err as NonZeroExitError).message).toBe(
+        '`node -e process.exit(1);` exited with a non-zero status (1)'
+      );
+    }
   });
 });
 
@@ -171,12 +191,12 @@ if (isWindows) {
         await proc;
         expect.fail('Expected to throw');
       } catch (err) {
-        expect(err instanceof NonZeroExitError).ok;
-        expect((err as NonZeroExitError).output?.stderr).toBe(
+        expect.assert(err instanceof NonZeroExitError);
+        expect(err.output?.stderr).toBe(
           "'definitelyNonExistent' is not recognized as an internal" +
             ' or external command,\r\noperable program or batch file.\r\n'
         );
-        expect((err as NonZeroExitError).output?.stdout).toBe('');
+        expect(err.output?.stdout).toBe('');
       }
     });
 


### PR DESCRIPTION
The default printed error message is a bit wordy and doesn't provide a lot of information. I fixed this by displaying the command that caused the error, and hide the `result` from the logs by making it non-enumerable.

Ideally, we don't pass the entire process object willy nilly, but it could potentially break users who would access it even if untyped. I went with the least breaking approach for now but making it non-enumerable.

Also, I made `exitCode` non-nullable. Since it's called `NonZeroExitError`, there's already an exit code.

---

With:
```ts
import {exec} from './dist/main.mjs';

await exec('git', ['rev-parse', 'abc'], {throwOnError: true});
```

Before:
```
file:///Users/bjorn/Work/oss/tinyexec/dist/main.mjs:284
                if (this._options.throwOnError && this.exitCode !== 0 && this.exitCode !== void 0) throw new k(this, i);
                                                                                                         ^

k [Error]: Process exited with non-zero status (128)
    at I._waitForOutput (file:///Users/bjorn/Work/oss/tinyexec/dist/main.mjs:284:92)
    at async file:///Users/bjorn/Work/oss/tinyexec/test.mjs:3:1 {
  result: I {
    _process: ChildProcess {
      _events: [Object: null prototype] {},
      _eventsCount: 0,
      _maxListeners: undefined,
      _closesNeeded: 3,
      _closesGot: 3,
      connected: false,
      signalCode: null,
      exitCode: 128,
      killed: false,
      spawnfile: 'git',
      _handle: null,
      spawnargs: [ 'git', 'rev-parse', 'abc' ],
      pid: 63048,
      stdin: Socket {
        connecting: false,
        _hadError: false,
        _parent: null,
        _host: null,
        _closeAfterHandlingError: false,
        _events: {
          close: undefined,
          error: undefined,
          prefinish: undefined,
          finish: undefined,
          drain: undefined,
          data: undefined,
          end: [Function: onReadableStreamEnd],
          readable: undefined
        },
        _readableState: ReadableState {
          highWaterMark: 65536,
          buffer: [],
          bufferIndex: 0,
          length: 0,
          pipes: [],
          awaitDrainWriters: null,
          readable: false,
          Symbol(kState): 1054580
        },
        _writableState: WritableState {
          highWaterMark: 65536,
          length: 0,
          corked: 0,
          onwrite: [Function (anonymous)],
          writelen: 0,
          bufferedIndex: 0,
          pendingcb: 0,
          Symbol(kState): 17564532,
          Symbol(kBufferedValue): null
        },
        allowHalfOpen: false,
        _maxListeners: undefined,
        _eventsCount: 1,
        _sockname: null,
        _pendingData: null,
        _pendingEncoding: '',
        server: null,
        _server: null,
        Symbol(async_id_symbol): 7,
        Symbol(kHandle): null,
        Symbol(lastWriteQueueSize): 0,
        Symbol(timeout): null,
        Symbol(kBuffer): null,
        Symbol(kBufferCb): null,
        Symbol(kBufferGen): null,
        Symbol(shapeMode): true,
        Symbol(kCapture): false,
        Symbol(kSetNoDelay): false,
        Symbol(kSetKeepAlive): false,
        Symbol(kSetKeepAliveInitialDelay): 0,
        Symbol(kSetTOS): undefined,
        Symbol(kBytesRead): 0,
        Symbol(kBytesWritten): 0
      },
      stdout: Socket {
        connecting: false,
        _hadError: false,
        _parent: null,
        _host: null,
        _closeAfterHandlingError: false,
        _events: {
          close: [
            [Function (anonymous)],
            [Function: onclose],
            Symbol(events.emitting): 0
          ],
          error: [Function: onerror],
          prefinish: undefined,
          finish: [Function: onfinish],
          drain: undefined,
          data: undefined,
          end: [
            [Function: onReadableStreamEnd],
            [Function: onend],
            Symbol(events.emitting): 0
          ],
          readable: [Function: next]
        },
        _readableState: ReadableState {
          highWaterMark: 65536,
          buffer: [],
          bufferIndex: 0,
          length: 0,
          pipes: [],
          awaitDrainWriters: null,
          Symbol(kState): 9996148
        },
        _writableState: WritableState {
          highWaterMark: 65536,
          length: 0,
          corked: 0,
          onwrite: [Function (anonymous)],
          writelen: 0,
          bufferedIndex: 0,
          pendingcb: 0,
          Symbol(kState): 1091310964,
          Symbol(kBufferedValue): null
        },
        allowHalfOpen: false,
        _maxListeners: undefined,
        _eventsCount: 5,
        _sockname: null,
        _pendingData: null,
        _pendingEncoding: '',
        server: null,
        _server: null,
        write: [Function: writeAfterFIN],
        Symbol(async_id_symbol): 8,
        Symbol(kHandle): null,
        Symbol(lastWriteQueueSize): 0,
        Symbol(timeout): null,
        Symbol(kBuffer): null,
        Symbol(kBufferCb): null,
        Symbol(kBufferGen): null,
        Symbol(shapeMode): true,
        Symbol(kCapture): false,
        Symbol(kSetNoDelay): false,
        Symbol(kSetKeepAlive): false,
        Symbol(kSetKeepAliveInitialDelay): 0,
        Symbol(kSetTOS): undefined,
        Symbol(kBytesRead): 4,
        Symbol(kBytesWritten): 0
      },
      stderr: Socket {
        connecting: false,
        _hadError: false,
        _parent: null,
        _host: null,
        _closeAfterHandlingError: false,
        _events: {
          close: [
            [Function (anonymous)],
            [Function: onclose],
            Symbol(events.emitting): 0
          ],
          error: [Function: onerror],
          prefinish: undefined,
          finish: [Function: onfinish],
          drain: undefined,
          data: undefined,
          end: [
            [Function: onReadableStreamEnd],
            [Function: onend],
            Symbol(events.emitting): 0
          ],
          readable: [Function: next]
        },
        _readableState: ReadableState {
          highWaterMark: 65536,
          buffer: [],
          bufferIndex: 0,
          length: 0,
          pipes: [],
          awaitDrainWriters: null,
          Symbol(kState): 9996148
        },
        _writableState: WritableState {
          highWaterMark: 65536,
          length: 0,
          corked: 0,
          onwrite: [Function (anonymous)],
          writelen: 0,
          bufferedIndex: 0,
          pendingcb: 0,
          Symbol(kState): 1091310964,
          Symbol(kBufferedValue): null
        },
        allowHalfOpen: false,
        _maxListeners: undefined,
        _eventsCount: 5,
        _sockname: null,
        _pendingData: null,
        _pendingEncoding: '',
        server: null,
        _server: null,
        write: [Function: writeAfterFIN],
        Symbol(async_id_symbol): 9,
        Symbol(kHandle): null,
        Symbol(lastWriteQueueSize): 0,
        Symbol(timeout): null,
        Symbol(kBuffer): null,
        Symbol(kBufferCb): null,
        Symbol(kBufferGen): null,
        Symbol(shapeMode): true,
        Symbol(kCapture): false,
        Symbol(kSetNoDelay): false,
        Symbol(kSetKeepAlive): false,
        Symbol(kSetKeepAliveInitialDelay): 0,
        Symbol(kSetTOS): undefined,
        Symbol(kBytesRead): 184,
        Symbol(kBytesWritten): 0
      },
      stdio: [
        Socket {
          connecting: false,
          _hadError: false,
          _parent: null,
          _host: null,
          _closeAfterHandlingError: false,
          _events: {
            close: undefined,
            error: undefined,
            prefinish: undefined,
            finish: undefined,
            drain: undefined,
            data: undefined,
            end: [Function: onReadableStreamEnd],
            readable: undefined
          },
          _readableState: ReadableState {
            highWaterMark: 65536,
            buffer: [],
            bufferIndex: 0,
            length: 0,
            pipes: [],
            awaitDrainWriters: null,
            readable: false,
            Symbol(kState): 1054580
          },
          _writableState: WritableState {
            highWaterMark: 65536,
            length: 0,
            corked: 0,
            onwrite: [Function (anonymous)],
            writelen: 0,
            bufferedIndex: 0,
            pendingcb: 0,
            Symbol(kState): 17564532,
            Symbol(kBufferedValue): null
          },
          allowHalfOpen: false,
          _maxListeners: undefined,
          _eventsCount: 1,
          _sockname: null,
          _pendingData: null,
          _pendingEncoding: '',
          server: null,
          _server: null,
          Symbol(async_id_symbol): 7,
          Symbol(kHandle): null,
          Symbol(lastWriteQueueSize): 0,
          Symbol(timeout): null,
          Symbol(kBuffer): null,
          Symbol(kBufferCb): null,
          Symbol(kBufferGen): null,
          Symbol(shapeMode): true,
          Symbol(kCapture): false,
          Symbol(kSetNoDelay): false,
          Symbol(kSetKeepAlive): false,
          Symbol(kSetKeepAliveInitialDelay): 0,
          Symbol(kSetTOS): undefined,
          Symbol(kBytesRead): 0,
          Symbol(kBytesWritten): 0
        },
        Socket {
          connecting: false,
          _hadError: false,
          _parent: null,
          _host: null,
          _closeAfterHandlingError: false,
          _events: {
            close: [Array],
            error: [Function: onerror],
            prefinish: undefined,
            finish: [Function: onfinish],
            drain: undefined,
            data: undefined,
            end: [Array],
            readable: [Function: next]
          },
          _readableState: ReadableState {
            highWaterMark: 65536,
            buffer: [],
            bufferIndex: 0,
            length: 0,
            pipes: [],
            awaitDrainWriters: null,
            Symbol(kState): 9996148
          },
          _writableState: WritableState {
            highWaterMark: 65536,
            length: 0,
            corked: 0,
            onwrite: [Function (anonymous)],
            writelen: 0,
            bufferedIndex: 0,
            pendingcb: 0,
            Symbol(kState): 1091310964,
            Symbol(kBufferedValue): null
          },
          allowHalfOpen: false,
          _maxListeners: undefined,
          _eventsCount: 5,
          _sockname: null,
          _pendingData: null,
          _pendingEncoding: '',
          server: null,
          _server: null,
          write: [Function: writeAfterFIN],
          Symbol(async_id_symbol): 8,
          Symbol(kHandle): null,
          Symbol(lastWriteQueueSize): 0,
          Symbol(timeout): null,
          Symbol(kBuffer): null,
          Symbol(kBufferCb): null,
          Symbol(kBufferGen): null,
          Symbol(shapeMode): true,
          Symbol(kCapture): false,
          Symbol(kSetNoDelay): false,
          Symbol(kSetKeepAlive): false,
          Symbol(kSetKeepAliveInitialDelay): 0,
          Symbol(kSetTOS): undefined,
          Symbol(kBytesRead): 4,
          Symbol(kBytesWritten): 0
        },
        Socket {
          connecting: false,
          _hadError: false,
          _parent: null,
          _host: null,
          _closeAfterHandlingError: false,
          _events: {
            close: [Array],
            error: [Function: onerror],
            prefinish: undefined,
            finish: [Function: onfinish],
            drain: undefined,
            data: undefined,
            end: [Array],
            readable: [Function: next]
          },
          _readableState: ReadableState {
            highWaterMark: 65536,
            buffer: [],
            bufferIndex: 0,
            length: 0,
            pipes: [],
            awaitDrainWriters: null,
            Symbol(kState): 9996148
          },
          _writableState: WritableState {
            highWaterMark: 65536,
            length: 0,
            corked: 0,
            onwrite: [Function (anonymous)],
            writelen: 0,
            bufferedIndex: 0,
            pendingcb: 0,
            Symbol(kState): 1091310964,
            Symbol(kBufferedValue): null
          },
          allowHalfOpen: false,
          _maxListeners: undefined,
          _eventsCount: 5,
          _sockname: null,
          _pendingData: null,
          _pendingEncoding: '',
          server: null,
          _server: null,
          write: [Function: writeAfterFIN],
          Symbol(async_id_symbol): 9,
          Symbol(kHandle): null,
          Symbol(lastWriteQueueSize): 0,
          Symbol(timeout): null,
          Symbol(kBuffer): null,
          Symbol(kBufferCb): null,
          Symbol(kBufferGen): null,
          Symbol(shapeMode): true,
          Symbol(kCapture): false,
          Symbol(kSetNoDelay): false,
          Symbol(kSetKeepAlive): false,
          Symbol(kSetKeepAliveInitialDelay): 0,
          Symbol(kSetTOS): undefined,
          Symbol(kBytesRead): 184,
          Symbol(kBytesWritten): 0
        }
      ],
      Symbol(shapeMode): false,
      Symbol(kCapture): false
    },
    _aborted: false,
    _options: { timeout: undefined, persist: false, throwOnError: true },
    _command: 'git',
    _args: [ 'rev-parse', 'abc' ],
    _resolveClose: [Function (anonymous)],
    _processClosed: Promise { undefined },
    _thrownError: undefined,
    _streamOut: Socket {
      connecting: false,
      _hadError: false,
      _parent: null,
      _host: null,
      _closeAfterHandlingError: false,
      _events: {
        close: [
          [Function (anonymous)],
          [Function: onclose],
          Symbol(events.emitting): 0
        ],
        error: [Function: onerror],
        prefinish: undefined,
        finish: [Function: onfinish],
        drain: undefined,
        data: undefined,
        end: [
          [Function: onReadableStreamEnd],
          [Function: onend],
          Symbol(events.emitting): 0
        ],
        readable: [Function: next]
      },
      _readableState: ReadableState {
        highWaterMark: 65536,
        buffer: [],
        bufferIndex: 0,
        length: 0,
        pipes: [],
        awaitDrainWriters: null,
        Symbol(kState): 9996148
      },
      _writableState: WritableState {
        highWaterMark: 65536,
        length: 0,
        corked: 0,
        onwrite: [Function (anonymous)],
        writelen: 0,
        bufferedIndex: 0,
        pendingcb: 0,
        Symbol(kState): 1091310964,
        Symbol(kBufferedValue): null
      },
      allowHalfOpen: false,
      _maxListeners: undefined,
      _eventsCount: 5,
      _sockname: null,
      _pendingData: null,
      _pendingEncoding: '',
      server: null,
      _server: null,
      write: [Function: writeAfterFIN],
      Symbol(async_id_symbol): 8,
      Symbol(kHandle): null,
      Symbol(lastWriteQueueSize): 0,
      Symbol(timeout): null,
      Symbol(kBuffer): null,
      Symbol(kBufferCb): null,
      Symbol(kBufferGen): null,
      Symbol(shapeMode): true,
      Symbol(kCapture): false,
      Symbol(kSetNoDelay): false,
      Symbol(kSetKeepAlive): false,
      Symbol(kSetKeepAliveInitialDelay): 0,
      Symbol(kSetTOS): undefined,
      Symbol(kBytesRead): 4,
      Symbol(kBytesWritten): 0
    },
    _streamErr: Socket {
      connecting: false,
      _hadError: false,
      _parent: null,
      _host: null,
      _closeAfterHandlingError: false,
      _events: {
        close: [
          [Function (anonymous)],
          [Function: onclose],
          Symbol(events.emitting): 0
        ],
        error: [Function: onerror],
        prefinish: undefined,
        finish: [Function: onfinish],
        drain: undefined,
        data: undefined,
        end: [
          [Function: onReadableStreamEnd],
          [Function: onend],
          Symbol(events.emitting): 0
        ],
        readable: [Function: next]
      },
      _readableState: ReadableState {
        highWaterMark: 65536,
        buffer: [],
        bufferIndex: 0,
        length: 0,
        pipes: [],
        awaitDrainWriters: null,
        Symbol(kState): 9996148
      },
      _writableState: WritableState {
        highWaterMark: 65536,
        length: 0,
        corked: 0,
        onwrite: [Function (anonymous)],
        writelen: 0,
        bufferedIndex: 0,
        pendingcb: 0,
        Symbol(kState): 1091310964,
        Symbol(kBufferedValue): null
      },
      allowHalfOpen: false,
      _maxListeners: undefined,
      _eventsCount: 5,
      _sockname: null,
      _pendingData: null,
      _pendingEncoding: '',
      server: null,
      _server: null,
      write: [Function: writeAfterFIN],
      Symbol(async_id_symbol): 9,
      Symbol(kHandle): null,
      Symbol(lastWriteQueueSize): 0,
      Symbol(timeout): null,
      Symbol(kBuffer): null,
      Symbol(kBufferCb): null,
      Symbol(kBufferGen): null,
      Symbol(shapeMode): true,
      Symbol(kCapture): false,
      Symbol(kSetNoDelay): false,
      Symbol(kSetKeepAlive): false,
      Symbol(kSetKeepAliveInitialDelay): 0,
      Symbol(kSetTOS): undefined,
      Symbol(kBytesRead): 184,
      Symbol(kBytesWritten): 0
    },
    _onError: [Function: _onError],
    _onClose: [Function: _onClose]
  },
  output: {
    stderr: "fatal: ambiguous argument 'abc': unknown revision or path not in the working tree.\n" +
      "Use '--' to separate paths from revisions, like this:\n" +
      "'git <command> [<revision>...] -- [<file>...]'\n",
    stdout: 'abc\n',
    exitCode: 128
  }
}
```


After:
```
file:///Users/bjorn/Work/oss/tinyexec/dist/main.mjs:291
                if (this._options.throwOnError && this.exitCode !== 0 && this.exitCode !== void 0) throw new k(this, i, this._command, this._args);
                                                                                                         ^

k [Error]: The command `git rev-parse abc` exited with a non-zero status (128)
    at I._waitForOutput (file:///Users/bjorn/Work/oss/tinyexec/dist/main.mjs:291:92)
    at async file:///Users/bjorn/Work/oss/tinyexec/test.mjs:3:1 {
  output: {
    stderr: "fatal: ambiguous argument 'abc': unknown revision or path not in the working tree.\n" +
      "Use '--' to separate paths from revisions, like this:\n" +
      "'git <command> [<revision>...] -- [<file>...]'\n",
    stdout: 'abc\n',
    exitCode: 128
  },
  exitCode: 128
}
```