### PR TITLE
fix: add a second pass of resolution with no extension

### DIFF
--- a/src/normalize.ts
+++ b/src/normalize.ts
@@ -16,6 +16,7 @@ const isWindowsExecutableRegExp = /\.(?:com|exe)$/i;
 const isNodeModulesCmdRegExp = /node_modules[\\/]\.bin[\\/][^\\/]+\.cmd$/i;
 const isWindows = process.platform === 'win32';
 const defaultPathExt = ['.EXE', '.CMD', '.BAT', '.COM'];
+const noPathExt = [''];
 
 interface NormalizedSpawnCommand {
   command: string;
@@ -148,30 +149,31 @@ function resolveCommand(command: string, options: SpawnOptions): string | null {
     command.includes('/') || command.includes('\\')
       ? ['']
       : [cwd, ...PATH.split(pathDelimiter)];
-  const pathExt = env.PATHEXT
-    ? env.PATHEXT.split(pathDelimiter)
-    : defaultPathExt;
+  let pathExt = env.PATHEXT ? env.PATHEXT.split(pathDelimiter) : defaultPathExt;
 
   if (command.includes('.') && pathExt[0] !== '') {
-    pathExt.unshift('');
+    pathExt = ['', ...pathExt];
   }
 
-  for (const path of pathEnv) {
-    const unquoted =
-      path.startsWith('"') && path.endsWith('"') && path.length > 1
-        ? path.slice(1, -1)
-        : path;
-    const dest = resolvePath(cwd, unquoted, command);
+  // The second pass tries to resolve the command with no extension
+  for (const extensions of [pathExt, noPathExt]) {
+    for (const path of pathEnv) {
+      const unquoted =
+        path.startsWith('"') && path.endsWith('"') && path.length > 1
+          ? path.slice(1, -1)
+          : path;
+      const dest = resolvePath(cwd, unquoted, command);
 
-    for (const ext of pathExt) {
-      const destWithExt = dest + ext;
+      for (const ext of extensions) {
+        const destWithExt = dest + ext;
 
-      try {
-        if (statSync(destWithExt).isFile()) {
-          return destWithExt;
+        try {
+          if (statSync(destWithExt).isFile()) {
+            return destWithExt;
+          }
+        } catch {
+          // do nothing, it didn't exist
         }
-      } catch {
-        // do nothing, it didn't exist
       }
     }
   }

--- a/src/test/normalize_test.ts
+++ b/src/test/normalize_test.ts
@@ -71,6 +71,14 @@ describe('normalizeSpawnCommand', () => {
       expect(normalized.args).toEqual([scriptPath]);
     });
 
+    test('detects shebang of a command without extension', () => {
+      const scriptPath = path.join(fixturesPath, 'shebang_script_noext');
+      const normalized = normalizeSpawnCommand(scriptPath, []);
+
+      expect(normalized.command).toBe('where');
+      expect(normalized.args).toEqual([scriptPath]);
+    });
+
     test('handles relative commands without extension', () => {
       const relativePath = path.relative(
         cwd,

--- a/test/fixtures/shebang_script_noext
+++ b/test/fixtures/shebang_script_noext
@@ -1,0 +1,2 @@
+#!where
+not a real script, just used to verify shebang parsing


### PR DESCRIPTION
Fixes #160

Currently, if the command includes a `.` (like `foo.js`), we search for
`foo.js`, `foo.js.EXE`, `foo.js.CMD`, etc.

However, if the command is `foo`, we only search for `foo.EXE`,
`foo.CMD`, etc.

This means we're not picking up files literally called `foo`.

The fix here does a second pass with no extensions. This means we do the
existing searching, and _if all else fails_, we look for the name as-is.
