### PR TITLE
fix: resolve `node_modules/.bin` from `nodeOptions.cwd` instead of current process cwd

### DIFF
--- a/src/env.ts
+++ b/src/env.ts
@@ -3,6 +3,7 @@ import {
   resolve as resolvePath,
   dirname
 } from 'node:path';
+import {fileURLToPath} from 'node:url';
 
 export type EnvLike = (typeof process)['env'];
 
@@ -34,11 +35,12 @@ export function getPathFromEnv(env: EnvLike): EnvPathInfo {
   return defaultEnvPathInfo;
 }
 
-function addNodeBinToPath(cwd: string, path: EnvPathInfo): EnvPathInfo {
+function addNodeBinToPath(cwd: URL | string, path: EnvPathInfo): EnvPathInfo {
   const parts = path.value.split(pathDelimiter);
   const nodeBinPaths: string[] = [];
 
-  let currentPath = cwd;
+  let currentPath =
+    typeof cwd === 'string' ? cwd : fileURLToPath(cwd, {windows: false});
   let lastPath: string;
 
   do {
@@ -55,7 +57,7 @@ function addNodeBinToPath(cwd: string, path: EnvPathInfo): EnvPathInfo {
 }
 
 export function computeEnv(
-  cwd: string,
+  cwd: URL | string,
   env?: EnvLike,
   nodePath: boolean = true
 ): EnvLike {

--- a/src/main.ts
+++ b/src/main.ts
@@ -78,18 +78,18 @@ export interface TinyExec {
   ): Result;
 }
 
-const defaultOptions: Partial<Options> = {
+const defaultOptions = {
   timeout: undefined,
   persist: false
-};
+} satisfies Partial<Options>;
 
-const defaultSyncOptions: Partial<SyncOptions> = {
+const defaultSyncOptions = {
   timeout: undefined
-};
+} satisfies Partial<SyncOptions>;
 
-const defaultNodeOptions: SpawnOptions = {
+const defaultNodeOptions = {
   windowsHide: true
-};
+} satisfies SpawnOptions;
 
 function combineSignals(signals: Iterable<AbortSignal>): AbortSignal {
   const controller = new AbortController();
@@ -294,7 +294,7 @@ export class ExecProcess implements Result {
     const nodeOptions = {
       ...defaultNodeOptions,
       ...options.nodeOptions
-    };
+    } satisfies SpawnOptions;
     const cwd = nodeOptions?.cwd ?? getCwd();
     const signals: AbortSignal[] = [];
 
@@ -384,10 +384,10 @@ export function xSync(
   options?: Partial<SyncOptions>
 ): SyncResult {
   const opts = {...defaultSyncOptions, ...options};
-  const nodeOptions: SpawnSyncOptions = {
-    windowsHide: true,
+  const nodeOptions = {
+    ...defaultNodeOptions,
     ...opts.nodeOptions
-  };
+  } satisfies SpawnSyncOptions;
   const cwd = nodeOptions?.cwd ?? getCwd();
 
   if (opts.timeout !== undefined) {

--- a/src/main.ts
+++ b/src/main.ts
@@ -290,12 +290,12 @@ export class ExecProcess implements Result {
   protected _streamErr?: Readable;
 
   public spawn(): void {
-    const cwd = getCwd();
     const options = this._options;
     const nodeOptions = {
       ...defaultNodeOptions,
       ...options.nodeOptions
     };
+    const cwd = nodeOptions?.cwd ?? getCwd();
     const signals: AbortSignal[] = [];
 
     this._resetState();
@@ -384,11 +384,11 @@ export function xSync(
   options?: Partial<SyncOptions>
 ): SyncResult {
   const opts = {...defaultSyncOptions, ...options};
-  const cwd = getCwd();
   const nodeOptions: SpawnSyncOptions = {
     windowsHide: true,
     ...opts.nodeOptions
   };
+  const cwd = nodeOptions?.cwd ?? getCwd();
 
   if (opts.timeout !== undefined) {
     nodeOptions.timeout = opts.timeout;

--- a/src/test/env_test.ts
+++ b/src/test/env_test.ts
@@ -123,4 +123,24 @@ describe('computeEnv', async () => {
     expect(env[pathKey]).toBe(expected);
     expect(explicit[pathKey]).toBe(expected);
   });
+
+  test('supports file URL for cwd', () => {
+    const cwd = new URL('file:///one/two/three');
+    const originalPath = path.join(pathSep, 'usr', 'local', 'bin');
+
+    const env = computeEnv(cwd, {
+      PATH: originalPath
+    });
+
+    const expected = [
+      path.resolve(pathSep, 'one', 'two', 'three', 'node_modules', '.bin'),
+      path.resolve(pathSep, 'one', 'two', 'node_modules', '.bin'),
+      path.resolve(pathSep, 'one', 'node_modules', '.bin'),
+      path.resolve(pathSep, 'node_modules', '.bin'),
+      path.dirname(process.execPath),
+      originalPath
+    ].join(pathDelimiter);
+
+    expect(env[pathKey]).toBe(expected);
+  });
 });

--- a/src/test/main_test.ts
+++ b/src/test/main_test.ts
@@ -4,6 +4,7 @@ import os from 'node:os';
 import fs from 'node:fs';
 import path from 'node:path';
 import {spawnSync} from 'node:child_process';
+import {pathToFileURL} from 'node:url';
 
 const isWindows = os.platform() === 'win32';
 const fixturesDir = path.join(import.meta.dirname, '../../test/fixtures');
@@ -14,7 +15,7 @@ const variants = [
   {name: 'sync', x: xSync, isAsync: false}
 ];
 
-describe.each(variants)('exec ($name)', ({x, isAsync}) => {
+describe.for(variants)('exec ($name)', ({x, isAsync}) => {
   test('pid is number', async () => {
     const proc = x('echo', ['foo']);
     await proc;
@@ -55,6 +56,47 @@ describe.each(variants)('exec ($name)', ({x, isAsync}) => {
     const result = await x('node', ['-e', "console.error('some error')"]);
     expect(result.stderr).toBe('some error\n');
     expect(result.stdout).toBe('');
+  });
+
+  test('node_modules/.bin is added to path as resolved from cwd', async () => {
+    const result = await x('node', ['-e', 'console.log(process.env.PATH)']);
+    expect(result.stdout).toMatch(
+      path.join(process.cwd(), 'node_modules', '.bin')
+    );
+  });
+
+  test('node_modules/.bin is added to path resolved from nodeOptions.cwd', async () => {
+    const result = await x('node', ['-e', 'console.log(process.env.PATH)'], {
+      nodeOptions: {cwd: fixturesDir}
+    });
+
+    // Adds ./node_modules/.bin relative to nodeOptions.cwd
+    expect(result.stdout).toMatch(
+      path.join(fixturesDir, 'node_modules', '.bin')
+    );
+
+    // Also adds from root of repository, two directories up from fixtures
+    const repoRootDir = path.join(fixturesDir, '../../');
+    expect(result.stdout).toMatch(
+      path.join(repoRootDir, 'node_modules', '.bin')
+    );
+  });
+
+  test('supports file URL as nodeOptions.cwd', async () => {
+    const result = await x('node', ['-e', 'console.log(process.env.PATH)'], {
+      nodeOptions: {cwd: pathToFileURL(fixturesDir)}
+    });
+
+    // Adds ./node_modules/.bin relative to nodeOptions.cwd
+    expect(result.stdout).toMatch(
+      path.join(fixturesDir, 'node_modules', '.bin')
+    );
+
+    // Also adds from root of repository, two directories up from fixtures
+    const repoRootDir = path.join(fixturesDir, '../../');
+    expect(result.stdout).toMatch(
+      path.join(repoRootDir, 'node_modules', '.bin')
+    );
   });
 });
 


### PR DESCRIPTION
When `tinyexec` is configured with the `nodeOptions.cwd` option, the local `node_modules/.bin` directories should be resolved and added to `PATH` starting from that directory, instead of the directory where `tinyexec` itself is running.